### PR TITLE
randpw Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ to_uuid: Makefile
 randpw: Makefile
 	@echo "Installing the randpw command" 
 	touch ${HOME}/.bash_aliases
-	grep -q -P '(randpw\(\) |alias randpw=)' ${HOME}/.bash_aliases || echo 'randpw() { for i in 10 16 32 48 64; do echo == $${i} digits ==; apg -a 1 -n 3 -m $${i} -x $${i} -MCLN; done }' >> ${HOME}/.bash_aliases
+	grep -q -P '(randpw\(\) |alias randpw=)' ${HOME}/.bash_aliases || echo 'randpw() { for i in 16 24 32 48; do echo == $${i} digits ==; apg -a 1 -n 5 -m $${i} -x $${i} -MCLN; done }' >> ${HOME}/.bash_aliases
 
 ## from_epoch		: Install the "from_epoch" command which converts time from epoch into gregorian
 from_epoch: Makefile


### PR DESCRIPTION
This pull request fixed a few issues...

It removes the 10 character password option as anything shorter that 11 characters can be cracked [within a persons lifetime](https://howsecureismypassword.net/).

It adds a 24 character password option as there seems to be an immediate need for shorter but as secure passwords.  We don't offer an 8 character password so we can't quickly add a 16 & an 8 character password together.  I feel that 4 characters is about right to manually remove or add to a password if other lengths are needed.

It removes the 64 character password option.  Unlike 24 characters, 64 characters can be quickly made with two 32 character passwords if it is needed (and I don't think it is needed that often)

It increases output of each password length to 5 passwords.  I found that when it was 3 that I was always selecting the middle one. I feel that the reason we offer multiple passwords is...
* Safety in numbers, if someone is shoulder surfing then it's harder to identify the one been used if it's in a block of passwords (more reason to increase it from 3 if I'm always picking the middle one).
* When building a server we don't typically just need one password so it gives us more to draw from without having to re-run the generator.

This combined with the above means that upping the output to 5 means it fills the standard sized terminal screen again :-)